### PR TITLE
상품 목록 페이지 2depth 경로 노출로 수정

### DIFF
--- a/src/app/category/_components/CategoryHeader.tsx
+++ b/src/app/category/_components/CategoryHeader.tsx
@@ -1,16 +1,53 @@
+'use client';
+
 import Image from 'next/image';
 import Link from 'next/link';
 import { ShoppingCartIcon } from '@heroicons/react/24/outline';
 import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import { useSearchParams } from 'next/navigation';
+import { useCategory } from '@/hooks/queries/useCategory';
 
 export default function CategoryHeader() {
+  const searchParams = useSearchParams();
+  const categoryId = searchParams.get('category');
+  const keyword = searchParams.get('name');
+  const { categories } = useCategory();
+
+  const getTitle = () => {
+    // 카테고리가 없고 검색어가 있는 경우
+    if (!categoryId && keyword) {
+      return `"${keyword}" 검색 결과`;
+    }
+
+    if (!categories || !categoryId) return '카테고리';
+
+    interface Category {
+      id: number;
+      name: string;
+      subCategories?: Category[];
+    }
+
+    const findCategory = (cats: Category[]): string | null => {
+      for (const cat of cats) {
+        if (String(cat.id) === categoryId) return cat.name;
+        if (cat.subCategories) {
+          const found = findCategory(cat.subCategories);
+          if (found) return found;
+        }
+      }
+      return null;
+    };
+
+    return findCategory(categories) || '카테고리';
+  };
+
   return (
     <header className="w-full h-[60] flex justify-between items-center px-4 shadow-md">
       <div className="flex gap-5">
         <Link href="/">
           <Image src="/assets/arrow.svg" width={24} height={24} alt="arrow" />
         </Link>
-        <span className="font-bold">카테고리</span>
+        <span className="font-bold">{getTitle()}</span>
       </div>
       <div className="flex gap-[15]">
         <div className="w-10 h-10 rounded-lg flex items-center justify-center bg-[#F6F8FB]">

--- a/src/app/products/_components/CategoryList.tsx
+++ b/src/app/products/_components/CategoryList.tsx
@@ -1,19 +1,29 @@
-const categories = [
-  { id: 1, name: '전체' },
-  { id: 2, name: '의류' },
-  { id: 3, name: '신발' },
-  { id: 4, name: '가방' },
-  { id: 5, name: '액세서리' },
-  { id: 6, name: '디지털' },
-];
+'use client';
+
+import { useCategory } from '@/hooks/queries/useCategory';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
 
 function CategoryList() {
+  const { categories, categoryLoading } = useCategory();
+
+  if (categoryLoading) {
+    return (
+      <div className="rounded-xl p-8">
+        <h2 className="text-lg font-bold mb-5">카테고리</h2>
+        <hr />
+        <div className="py-5">
+          <LoadingSpinner size={30} />
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="rounded-xl p-8">
       <h2 className="text-lg font-bold mb-5">카테고리</h2>
       <hr />
       <ul className="flex lg:flex-col overflow-x-auto lg:overflow-x-visible pb-2 lg:pb-0 gap-2 mt-3">
-        {categories.map((category) => (
+        {categories?.map((category) => (
           <li key={category.id} className="flex-shrink-0 lg:flex-shrink">
             <button className="w-full text-left py-2">{category.name}</button>
           </li>

--- a/src/app/products/_components/CategoryList.tsx
+++ b/src/app/products/_components/CategoryList.tsx
@@ -2,9 +2,20 @@
 
 import { useCategory } from '@/hooks/queries/useCategory';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 
 function CategoryList() {
   const { categories, categoryLoading } = useCategory();
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const categoryId = searchParams.get('category');
+
+  const handleCategoryClick = (subCategoryId: number) => {
+    const params = new URLSearchParams(searchParams);
+    params.set('category', subCategoryId.toString());
+    router.push(`${pathname}?${params.toString()}`);
+  };
 
   if (categoryLoading) {
     return (
@@ -18,6 +29,22 @@ function CategoryList() {
     );
   }
 
+  // Find parent category by checking all categories and their subcategories
+  const findParentCategory = () => {
+    for (const category of categories || []) {
+      if (category.id.toString() === categoryId) {
+        return category;
+      }
+      const subCategory = category.subCategories?.find((sub) => sub.id.toString() === categoryId);
+      if (subCategory) {
+        return category;
+      }
+    }
+    return null;
+  };
+
+  const parentCategory = findParentCategory();
+
   return (
     <div className="rounded-xl p-8">
       <h2 className="text-lg font-bold mb-5">카테고리</h2>
@@ -25,7 +52,22 @@ function CategoryList() {
       <ul className="flex lg:flex-col overflow-x-auto lg:overflow-x-visible pb-2 lg:pb-0 gap-2 mt-3">
         {categories?.map((category) => (
           <li key={category.id} className="flex-shrink-0 lg:flex-shrink">
-            <button className="w-full text-left py-2">{category.name}</button>
+            {category.id === parentCategory?.id && category.subCategories && category.subCategories.length > 0 && (
+              <ul>
+                {category.subCategories.map((subCategory) => (
+                  <li key={subCategory.id}>
+                    <button
+                      className={`w-full text-left py-2 text-sm ${
+                        subCategory.id.toString() === categoryId ? 'text-blue-600 font-bold' : 'text-gray-600'
+                      }`}
+                      onClick={() => handleCategoryClick(subCategory.id)}
+                    >
+                      {subCategory.name}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
           </li>
         ))}
       </ul>

--- a/src/app/products/_components/CategoryList.tsx
+++ b/src/app/products/_components/CategoryList.tsx
@@ -14,6 +14,7 @@ function CategoryList() {
   const handleCategoryClick = (subCategoryId: number) => {
     const params = new URLSearchParams(searchParams);
     params.set('category', subCategoryId.toString());
+    params.delete('name'); // Remove search query when changing category
     router.push(`${pathname}?${params.toString()}`);
   };
 

--- a/src/app/products/_components/filter/PriceFilter/index.tsx
+++ b/src/app/products/_components/filter/PriceFilter/index.tsx
@@ -39,6 +39,7 @@ export const PriceFilter: React.FC<PriceFilterProps> = ({
       <div className="flex gap-2 items-center justify-between">
         <input
           type="number"
+          step="500"
           value={priceRange.min}
           className="w-2/5 p-2 border border-zinc-300 rounded text-sm"
           onChange={(e) => onInputChange('min', Number(e.target.value))}
@@ -46,6 +47,7 @@ export const PriceFilter: React.FC<PriceFilterProps> = ({
         <span className="text-neutral-500">~</span>
         <input
           type="number"
+          step="500"
           value={priceRange.max}
           className="w-2/5 p-2 border border-zinc-300 rounded text-sm"
           onChange={(e) => onInputChange('max', Number(e.target.value))}

--- a/src/app/products/_components/filter/constants.ts
+++ b/src/app/products/_components/filter/constants.ts
@@ -1,7 +1,17 @@
-export const ALLOWED_FILTERS = ['Color'];
+export const ALLOWED_FILTERS = ['색상'];
 
 export const COLOR_MAPPING: Record<string, string> = {
-  'Black': 'black',
-  'White': 'white',
-  'Gray': 'gray',
+  검정: '#000000',
+  은색: '#C0C0C0',
+  흰색: '#FFFFFF',
+  빨강: '#FF0000',
+  파랑: '#0000FF',
+  초록: '#008000',
+  노랑: '#FFFF00',
+  보라: '#800080',
+  분홍: '#FFC0CB',
+  갈색: '#A52A2A',
+  주황: '#FFA500',
+  남색: '#000080',
+  베이지: '#F5F5DC',
 };

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -21,90 +21,101 @@ const ProductSkeletons = () => {
   );
 };
 
-const ProductContent = async ({ searchParams }: { searchParams: { [key: string]: string | undefined } }) => {
-  const { keyword, priceMin, priceMax, rating, pageNumber, pageSize } = searchParams;
-
-  const products = await getProducts({
-    keyword,
-    priceMin: priceMin ? Number(priceMin) : undefined,
-    priceMax: priceMax ? Number(priceMax) : undefined,
-    rating: rating ? Number(rating) : undefined,
-    pageNumber: pageNumber ? Number(pageNumber) : undefined,
-    pageSize: pageSize ? Number(pageSize) : undefined,
-    productId: undefined,
-    categoryId: undefined,
-  });
-
-  if (!products) {
-    return <ProductSkeletons />;
-  }
-
-  return (
-    <div className="lg:px-0 px-4">
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-5 bg-slate-50 border border-slate-300 rounded-xl p-7">
-        {products.map((product) => (
-          <Card
-            key={product.productId}
-            imgUrl={product.options[0].optionDetails[0].url}
-            title={product.name}
-            price={product.price}
-            review={3}
-          />
-        ))}
-      </div>
-    </div>
-  );
-};
-
-export default async function ProductsPage({ searchParams }: { searchParams: { [key: string]: string | undefined } }) {
+const ProductContent = async ({
+  searchParams,
+}: {
+  searchParams: Promise<{
+    keyword?: string;
+    priceMin?: string;
+    priceMax?: string;
+    rating?: string;
+    pageNumber?: string;
+    pageSize?: string;
+  }>;
+}) => {
   try {
-    const { keyword, priceMin, priceMax, rating, pageNumber, pageSize } = searchParams;
+    const params = await searchParams;
 
     const products = await getProducts({
-      keyword,
-      priceMin: priceMin ? Number(priceMin) : undefined,
-      priceMax: priceMax ? Number(priceMax) : undefined,
-      rating: rating ? Number(rating) : undefined,
-      pageNumber: pageNumber ? Number(pageNumber) : undefined,
-      pageSize: pageSize ? Number(pageSize) : undefined,
+      keyword: params.keyword,
+      priceMin: params.priceMin ? Number(params.priceMin) : undefined,
+      priceMax: params.priceMax ? Number(params.priceMax) : undefined,
+      rating: params.rating ? Number(params.rating) : undefined,
+      pageNumber: params.pageNumber ? Number(params.pageNumber) : undefined,
+      pageSize: params.pageSize ? Number(params.pageSize) : undefined,
       productId: undefined,
       categoryId: undefined,
     });
 
+    if (!products) {
+      return <ProductSkeletons />;
+    }
+
     return (
       <>
-        <Header />
-        <div className="max-w-custom mx-auto lg:pt-8 pb-8">
-          <div className="flex flex-col lg:flex-row lg:gap-5">
-            {/* 왼쪽 사이드바 영역 */}
-            <div className="lg:w-1/4">
-              {/* 카테고리 영역 */}
-              <div className="w-full h-fit bg-slate-50 border border-slate-300 rounded-xl hidden lg:block mb-5">
-                <CategoryList />
-              </div>
-              {/* 필터 영역 */}
-              <div className="w-full h-fit bg-slate-50 border border-slate-300 rounded-xl hidden lg:block mb-5">
-                <Filter products={products} />
-              </div>
-            </div>
-
-            {/* 상품 목록 영역 */}
-            <main className="lg:w-3/4">
-              <div className="lg:mb-8 mb-1">
-                <Breadcrumbs />
-              </div>
-              <div className="lg:hidden block mb-8 px-3 py-2 bg-slate-50 border-slate-300 border">
-                <MobileFilter products={products} />
-              </div>
-              <Suspense fallback={<ProductSkeletons />}>
-                <ProductContent searchParams={searchParams} />
-              </Suspense>
-            </main>
+        {/* 왼쪽 사이드바 영역 */}
+        <div className="lg:w-1/4">
+          {/* 카테고리 영역 */}
+          <div className="w-full h-fit bg-slate-50 border border-slate-300 rounded-xl hidden lg:block mb-5">
+            <CategoryList />
+          </div>
+          {/* 필터 영역 */}
+          <div className="w-full h-fit bg-slate-50 border border-slate-300 rounded-xl hidden lg:block mb-5">
+            <Filter products={products} />
           </div>
         </div>
+
+        {/* 상품 목록 영역 */}
+        <main className="lg:w-3/4">
+          <div className="lg:mb-8 mb-1">
+            <Breadcrumbs />
+          </div>
+          <div className="lg:hidden block mb-8 px-3 py-2 bg-slate-50 border-slate-300 border">
+            <MobileFilter products={products} />
+          </div>
+          <div className="lg:px-0 px-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-5 bg-slate-50 border border-slate-300 rounded-xl p-7">
+              {products.map((product) => (
+                <Card
+                  key={product.productId}
+                  imgUrl={product.options[0].optionDetails[0].url}
+                  title={product.name}
+                  price={product.price}
+                  review={3}
+                />
+              ))}
+            </div>
+          </div>
+        </main>
       </>
     );
   } catch {
     return <div>상품을 불러오는데 실패했습니다. 잠시 후 다시 시도해주세요.</div>;
   }
+};
+
+export default async function ProductsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{
+    keyword?: string;
+    priceMin?: string;
+    priceMax?: string;
+    rating?: string;
+    pageNumber?: string;
+    pageSize?: string;
+  }>;
+}) {
+  return (
+    <>
+      <Header />
+      <div className="max-w-custom mx-auto lg:pt-8 pb-8">
+        <div className="flex flex-col lg:flex-row lg:gap-5">
+          <Suspense fallback={<ProductSkeletons />}>
+            <ProductContent searchParams={searchParams} />
+          </Suspense>
+        </div>
+      </div>
+    </>
+  );
 }

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -8,6 +8,7 @@ import { getProducts } from '@/api/product';
 import { MobileFilter } from '@/app/products/_components/filter/MobileFilter';
 import { Header } from '@/components/layout';
 import { Suspense } from 'react';
+import CategoryHeader from '../category/_components/CategoryHeader';
 
 const ProductSkeletons = () => {
   return (
@@ -108,7 +109,13 @@ export default async function ProductsPage({
 }) {
   return (
     <>
-      <Header />
+      <div className="lg:hidden">
+        <CategoryHeader />
+      </div>
+
+      <div className="hidden md:block">
+        <Header />
+      </div>
       <div className="max-w-custom mx-auto lg:pt-8 pb-8">
         <div className="flex flex-col lg:flex-row lg:gap-5">
           <Suspense fallback={<ProductSkeletons />}>

--- a/src/components/common/Breadcrumbs.tsx
+++ b/src/components/common/Breadcrumbs.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { SORT_OPTIONS } from '@/api/product';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import SortDropdown from './SortDropdown';
 
@@ -58,9 +59,16 @@ function BreadcrumbDropdown({ label, items, onSelect }: BreadcrumbDropdownProps)
 }
 
 export default function Breadcrumbs() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const [selectedCategory, setSelectedCategory] = useState<string>('남성의류');
   const [selectedOuter, setSelectedOuter] = useState<string>('아우터');
-  const [selectedSort, setSelectedSort] = useState<SORT_OPTIONS>('PRICE_ASC');
+  const [selectedSort, setSelectedSort] = useState<SORT_OPTIONS>(() => {
+    const sortFromUrl = searchParams.get('sortOption') as SORT_OPTIONS;
+    return sortFromUrl && Object.values(SORT_OPTIONS_CONFIG).some((option) => option.value === sortFromUrl)
+      ? sortFromUrl
+      : 'PRICE_ASC';
+  });
 
   const getCurrentSortLabel = (value: SORT_OPTIONS): string => {
     return SORT_OPTIONS_CONFIG.find((option) => option.value === value)?.label ?? '';
@@ -95,11 +103,11 @@ export default function Breadcrumbs() {
         onSelect={(label: string) => {
           const sortValue = getSortValueByLabel(label);
           setSelectedSort(sortValue);
-          
+
           // URL 업데이트
-          const searchParams = new URLSearchParams(window.location.search);
-          searchParams.set('sortOption', sortValue);
-          window.location.search = searchParams.toString();
+          const newSearchParams = new URLSearchParams(searchParams.toString());
+          newSearchParams.set('sortOption', sortValue);
+          router.push(`?${newSearchParams.toString()}`);
         }}
       />
     </div>

--- a/src/components/common/Breadcrumbs.tsx
+++ b/src/components/common/Breadcrumbs.tsx
@@ -1,35 +1,16 @@
 'use client';
 
-import { useState } from 'react';
-import Image from 'next/image';
-import { ChevronRightIcon } from '@heroicons/react/24/solid';
-import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator } from '@/components/ui/breadcrumb';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
+import { useState, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+
 import { SORT_OPTIONS } from '@/api/product';
-import { useRouter, useSearchParams } from 'next/navigation';
 
 import SortDropdown from './SortDropdown';
-
-interface BreadcrumbDropdownProps {
-  label: string;
-  items: string[];
-  onSelect: (item: string) => void;
-}
 
 interface SortOption {
   value: SORT_OPTIONS;
   label: string;
 }
-
-const categoryItems = {
-  clothing: ['상의', '하의', '아우터'],
-  outer: ['코트', '자켓', '패딩'],
-};
 
 const SORT_OPTIONS_CONFIG: SortOption[] = [
   { value: 'PRICE_ASC', label: '낮은가격순' },
@@ -38,37 +19,15 @@ const SORT_OPTIONS_CONFIG: SortOption[] = [
   { value: 'CREATE_DESC', label: '등록순' },
 ];
 
-function BreadcrumbDropdown({ label, items, onSelect }: BreadcrumbDropdownProps) {
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild className="flex items-center gap-1 outline-none">
-        <button className="px-2">
-          {label}
-          <Image src="/assets/dropdownDown.svg" width={20} height={20} alt="dropdown arrow" />
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent>
-        {items.map((item) => (
-          <DropdownMenuItem key={item} onSelect={() => onSelect(item)}>
-            {item}
-          </DropdownMenuItem>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
 export default function Breadcrumbs() {
-  const router = useRouter();
+  const [selectedSort, setSelectedSort] = useState<SORT_OPTIONS>('PRICE_ASC');
+  const [searchQuery, setSearchQuery] = useState<string>('');
   const searchParams = useSearchParams();
-  const [selectedCategory, setSelectedCategory] = useState<string>('남성의류');
-  const [selectedOuter, setSelectedOuter] = useState<string>('아우터');
-  const [selectedSort, setSelectedSort] = useState<SORT_OPTIONS>(() => {
-    const sortFromUrl = searchParams.get('sortOption') as SORT_OPTIONS;
-    return sortFromUrl && Object.values(SORT_OPTIONS_CONFIG).some((option) => option.value === sortFromUrl)
-      ? sortFromUrl
-      : 'PRICE_ASC';
-  });
+
+  useEffect(() => {
+    const query = searchParams.get('name');
+    setSearchQuery(query ? decodeURIComponent(query) : '');
+  }, [searchParams]); // Update searchQuery when URL parameters change
 
   const getCurrentSortLabel = (value: SORT_OPTIONS): string => {
     return SORT_OPTIONS_CONFIG.find((option) => option.value === value)?.label ?? '';
@@ -78,37 +37,29 @@ export default function Breadcrumbs() {
     return SORT_OPTIONS_CONFIG.find((option) => option.label === label)?.value ?? 'CREATE_DESC';
   };
 
+  const handleSortChange = (label: string) => {
+    const sortValue = getSortValueByLabel(label);
+    setSelectedSort(sortValue);
+
+    const params = new URLSearchParams(searchParams);
+    params.set('sortOption', sortValue);
+    window.location.search = params.toString();
+  };
+
   return (
     <div className="flex items-center justify-between lg:px-7 lg:py-4 px-3 py-2 bg-slate-50 lg:border border-slate-300 lg:rounded-xl">
-      <Breadcrumb className="flex items-center gap-2 list-none">
-        <BreadcrumbItem className="border border-slate-300 rounded-full bg-white px-3 py-2 text-sm text-nowrap">
-          <BreadcrumbLink href="/">홈</BreadcrumbLink>
-        </BreadcrumbItem>
-        <BreadcrumbSeparator>
-          <ChevronRightIcon className="w-6 h-6" />
-        </BreadcrumbSeparator>
-        <BreadcrumbItem className="border border-slate-300 rounded-full bg-white px-1 py-2 text-sm text-nowrap">
-          <BreadcrumbDropdown label={selectedCategory} items={categoryItems.clothing} onSelect={setSelectedCategory} />
-        </BreadcrumbItem>
-        <BreadcrumbSeparator>
-          <ChevronRightIcon className="w-6 h-6" />
-        </BreadcrumbSeparator>
-        <BreadcrumbItem className="border border-slate-300 rounded-full bg-white px-1 py-2 text-sm text-nowrap">
-          <BreadcrumbDropdown label={selectedOuter} items={categoryItems.outer} onSelect={setSelectedOuter} />
-        </BreadcrumbItem>
-      </Breadcrumb>
+      <div className="flex items-center">
+        {searchQuery && (
+          <div className="flex items-center gap-2 px-3 py-1 bg-white rounded-lg border border-slate-200 shadow-sm">
+            <span className="text-slate-500 text-sm font-medium">검색어:</span>
+            <span className="text-slate-700 text-sm">{searchQuery}</span>
+          </div>
+        )}
+      </div>
       <SortDropdown
         label={getCurrentSortLabel(selectedSort)}
         items={SORT_OPTIONS_CONFIG.map((option) => option.label)}
-        onSelect={(label: string) => {
-          const sortValue = getSortValueByLabel(label);
-          setSelectedSort(sortValue);
-
-          // URL 업데이트
-          const newSearchParams = new URLSearchParams(searchParams.toString());
-          newSearchParams.set('sortOption', sortValue);
-          router.push(`?${newSearchParams.toString()}`);
-        }}
+        onSelect={handleSortChange}
       />
     </div>
   );

--- a/src/components/common/SearchForm.tsx
+++ b/src/components/common/SearchForm.tsx
@@ -21,8 +21,14 @@ export default function SearchInput({ category, classname, onSearch }: Props) {
     const nameParam = searchParams.get('name');
     if (nameParam) {
       setInputValue(nameParam);
+    } else {
+      setInputValue(''); // Clear input when name parameter is removed
     }
-  }, [searchParams]);
+  }, [searchParams]); // Update when URL parameters change
+
+  useEffect(() => {
+    setInputValue('');
+  }, [category?.value]);
 
   const handleSearch = () => {
     if (inputValue.trim() !== '') {


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

더미 데이터로 구성되었던 상품 목록 페이지의 좌측 네비게이션 필터를 2depth 경로로 노출되도록 수정했습니다. 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

![Feb-04-2025 10-07-51](https://github.com/user-attachments/assets/90ff96d1-f1a6-4ac5-b4f2-b659af68ea62)



## 💬 공유사항 to 리뷰어

1. 카테고리 영역에도 로딩바가 나오는지 확인해주세요.
2. 2depth 네비게이션 영역으로 정상적으로 페이지가 넘어가는지 확인해주세요.

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
