### PR TITLE
fix: 초기화 버튼 클릭시 페이지도 1페이지로 이동하도록 수정

### DIFF
--- a/src/app/products/_components/filter/Filter.tsx
+++ b/src/app/products/_components/filter/Filter.tsx
@@ -110,6 +110,7 @@ const Filter: React.FC<FilterProps> = ({ products }) => {
     params.delete('priceMin');
     params.delete('priceMax');
     params.delete('rating');
+    params.set('pageNumber', '0');
     router.push(`?${params.toString()}`);
     setSelectedPriceRange(undefined);
     setSelectedRating(null);

--- a/src/app/products/_components/filter/MobileFilter.tsx
+++ b/src/app/products/_components/filter/MobileFilter.tsx
@@ -132,6 +132,7 @@ export const MobileFilter: React.FC<FilterProps> = ({ products }) => {
     params.delete('priceMin');
     params.delete('priceMax');
     params.delete('rating');
+    params.set('pageNumber', '0');
     router.push(`?${params.toString()}`);
 
     setSelectedPriceRange(undefined);


### PR DESCRIPTION
## #️⃣ Issue Number

https://github.com/FC-InnerCircle-ICD2/commerce-FE/issues/65

## 📝 요약(Summary)

초기화 버튼 클릭시 페이지도 1페이지로 이동하도록 수정했습니다. 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

https://www.notion.so/PC-MOBILE-1a2d5beeb0c080df8f3df56abb91c923

피드백에서는 초기화 버튼 클릭시 검색어까지 초기화 되도록 쓰여있었는데 이 부분은 논의가 필요할 것 같아 작업에 추가하지 않았습니다. 
의견 있으신 분들은 코멘트 남겨주세요

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
