### PR TITLE
fix: 필터 적용 시 페이지 번호를 0으로 재설정

### DIFF
--- a/src/app/products/_components/filter/Filter.tsx
+++ b/src/app/products/_components/filter/Filter.tsx
@@ -91,7 +91,7 @@ const Filter: React.FC<FilterProps> = ({ products }) => {
     } else {
       params.delete('priceMax');
     }
-
+    params.set('pageNumber', '0');
     router.push(`/products?${params.toString()}`);
     setSelectedPriceRange(priceRange);
   };
@@ -110,6 +110,7 @@ const Filter: React.FC<FilterProps> = ({ products }) => {
     params.delete('priceMin');
     params.delete('priceMax');
     params.delete('rating');
+    params.set('pageNumber', '0');
     router.push(`?${params.toString()}`);
     setSelectedPriceRange(undefined);
     setSelectedRating(null);
@@ -145,6 +146,7 @@ const Filter: React.FC<FilterProps> = ({ products }) => {
               const params = new URLSearchParams(searchParams?.toString() || '');
               params.delete('priceMin');
               params.delete('priceMax');
+              params.set('pageNumber', '0');
               router.push(`/products?${params.toString()}`);
               setSelectedPriceRange(undefined);
             }}
@@ -152,6 +154,7 @@ const Filter: React.FC<FilterProps> = ({ products }) => {
             onRatingRemove={() => {
               const params = new URLSearchParams(searchParams?.toString() || '');
               params.delete('rating');
+              params.set('pageNumber', '0');
               router.push(`/products?${params.toString()}`);
               setSelectedRating(null);
             }}

--- a/src/app/products/_components/filter/RatingFilter/index.tsx
+++ b/src/app/products/_components/filter/RatingFilter/index.tsx
@@ -14,6 +14,7 @@ export const RatingFilter = () => {
     } else {
       params.set('rating', rating.toString());
     }
+    params.set('pageNumber', '0');
     router.push(`?${params.toString()}`);
   };
 


### PR DESCRIPTION
## #️⃣ Issue Number

https://github.com/FC-InnerCircle-ICD2/commerce-FE/issues/63

## 📝 요약(Summary)

필터 적용 시 페이지 번호를 0으로 재설정되지 않는 버그 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
